### PR TITLE
fix: Update n_jobs default value to use all processors

### DIFF
--- a/siapy/optimizers/configs.py
+++ b/siapy/optimizers/configs.py
@@ -29,7 +29,7 @@ class OptimizeStudyConfig(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
     n_trials: int | None = None
     timeout: float | None = None
-    n_jobs: int = 1
+    n_jobs: int = -1
     catch: Iterable[type[Exception]] | type[Exception] = ()
     callbacks: (
         list[Callable[[optuna.study.Study, optuna.trial.FrozenTrial], None]] | None

--- a/siapy/optimizers/scorers.py
+++ b/siapy/optimizers/scorers.py
@@ -1,5 +1,5 @@
 from functools import partial
-from typing import Iterable, Literal
+from typing import Annotated, Iterable, Literal
 
 import numpy as np
 from sklearn import model_selection
@@ -38,6 +38,10 @@ class Scorer:
         | Iterable
         | Literal["RepeatedKFold", "RepeatedStratifiedKFold"]
         | None = None,
+        n_jobs: Annotated[
+            int | None,
+            "Number of jobs to run in parallel. `-1` means using all processors.",
+        ] = None,
     ) -> "Scorer":
         if isinstance(cv, str) and cv in ["RepeatedKFold", "RepeatedStratifiedKFold"]:
             cv = initialize_object(
@@ -52,7 +56,7 @@ class Scorer:
             scoring=scoring,
             cv=cv,  # type: ignore
             groups=None,
-            n_jobs=1,
+            n_jobs=n_jobs,
             verbose=0,
             fit_params=None,
             pre_dispatch=1,

--- a/tests/optimizers/test_optimizers_configs.py
+++ b/tests/optimizers/test_optimizers_configs.py
@@ -24,7 +24,7 @@ def test_optimize_study_config_defaults():
     config = OptimizeStudyConfig()
     assert config.n_trials is None
     assert config.timeout is None
-    assert config.n_jobs == 1
+    assert config.n_jobs == -1
     assert config.catch == ()
     assert config.callbacks is None
     assert config.gc_after_trial is False


### PR DESCRIPTION
- Updated the default value of `n_jobs` in the `OptimizeStudyConfig` class to `-1`, which means using all available processors for parallel processing.
- Updated the `n_jobs` parameter in the `Scorer` class to accept `Annotated[int | None, "Number of jobs to run in parallel. '-1' means using all processors."]` type hint.

## Description

<!--
    - Add 1-2 sentences explaining the purpose of this PR.
    - (Optionally] Add commit ID and [GitHub will autolink](https://help.github.com/en/github/writing-on-github/autolinked-references-and-urls).
    - (Optionally] Reference related commits, issues and pull requests. Type `#` and select from the list.
-->

## Checklist

- [ ] I have reviewed the [Guidelines for Contributing](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md).
